### PR TITLE
add new path to libindisearchpaths

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,7 @@ libindisearchpaths = [
     "/usr/lib64",
     "/lib",
     "/lib64",
+    "/usr/local/lib/" + march,
     "/usr/local/lib",
 ]
 


### PR DESCRIPTION
When installing indi on arm64 on Raspbian 11 to /usr/local, the libraries are installed to /usr/local/lib/aarch64-linux-gnu