### PR TITLE
Address issues with the example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,15 +109,15 @@ class IndiClient(PyIndi.BaseClient):
     def removeProperty(self, p):
         self.logger.info("remove property "+ p.getName() + " for device "+ p.getDeviceName())
     def newBLOB(self, bp):
-        self.logger.info("new BLOB "+ bp.name.decode())
+        self.logger.info("new BLOB "+ bp.name)
     def newSwitch(self, svp):
-        self.logger.info ("new Switch "+ svp.name.decode() + " for device "+ svp.device.decode())
+        self.logger.info ("new Switch "+ svp.name + " for device "+ svp.device)
     def newNumber(self, nvp):
-        self.logger.info("new Number "+ nvp.name.decode() + " for device "+ nvp.device.decode())
+        self.logger.info("new Number "+ nvp.name + " for device "+ nvp.device)
     def newText(self, tvp):
-        self.logger.info("new Text "+ tvp.name.decode() + " for device "+ tvp.device.decode())
+        self.logger.info("new Text "+ tvp.name + " for device "+ tvp.device)
     def newLight(self, lvp):
-        self.logger.info("new Light "+ lvp.name.decode() + " for device "+ lvp.device.decode())
+        self.logger.info("new Light "+ lvp.name + " for device "+ lvp.device)
     def newMessage(self, d, m):
         self.logger.info("new Message "+ d.messageQueue(m))
     def serverConnected(self):

--- a/indiclientpython.i
+++ b/indiclientpython.i
@@ -7,6 +7,7 @@
 
 
 #include <indiproperty.h>
+#include <indiproperties.h>
 
 #include <indipropertybasic.h>
 #include <indipropertytext.h>
@@ -185,6 +186,26 @@ B_ONLY
     return result;
   }
  };
+
+
+%ignore INDI::Properties::at;
+%ignore INDI::Properties::front;
+%ignore INDI::Properties::back;
+%ignore INDI::Properties::empty;
+
+%include <indiproperties.h>
+
+%extend INDI::Properties {
+  INDI::Property * __getitem__(int index) {
+    if ((unsigned int)index >= $self->size()) throw std::out_of_range("Properties index out of bounds");
+    return &($self->at(index));
+  }
+
+  int __len__() {
+    return $self->size();
+  }
+}
+
 
 %extend INDI::BaseClient {
   %typemap(in) (char *data, long len) {

--- a/setup.py
+++ b/setup.py
@@ -64,13 +64,13 @@ pyindi_module = Extension(
 class CustomBuild(build):
     def run(self):
         self.run_command("build_ext")
-        super().run()
+        build.run(self)
 
 
 class CustomInstall(install):
     def run(self):
         self.run_command("build_ext")
-        super().run()
+        install.run(self)
 
 
 # readme = open(join(root_dir, 'README.rst'))


### PR DESCRIPTION
The first and most critical issue is that there is no SWIG wrapper defined for INDI::Properties, so `d.getProperties()` returns a non-iterable generic proxy for `PySwigObject *`. This was addressed by adding `%include <indiproperties.h>` and definitions for `__getitem__` and `__len__` to the SWIG template. I believe this also addresses a warning about a missing destructor call. I had to tell SWIG to ignore the `at`, `front`, and `back` member functions to prevent C++ compilation errors related to creating pointers to references (obscured by a typedef used in the method declaration), and also the `empty` member function which for some reason caused a runtime link error due to a missing symbol when the PyIndi library was loaded. (Perhaps the optimization settings differ between the system INDI library and the SWIG wrapper, so the INDI library expected `empty` to be inlined but the wrapper failed to do so?)

The second issue, easily corrected, is that there is no .decode() method on the objects returned by `.name` and `.device`. I tested this in both Python 3.10 and Python 2.7 and in both environments it sufficed to simply remove the `.decode()` calls, as the objects are already of type `str`.

Finally, in testing the SWIG wrapper changes I found an error related to the use of `super()` without arguments in the CustomInstall class when running the `setup.py install` command with Python 2.7. This was addressed by explicity invoking the `.run()` method on the base class, which works in both Python 2.7 and Python 3.10.