### PR TITLE
Bump version to 1.9.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ pyindi-client ![tests](https://github.com/indilib/pyindi-client/actions/workflow
 =============
 
 
-version : v1.9.1
+version : v1.9.9
 
 An [INDI](http://indilib.org/) Client Python API, auto-generated from
 the official C++ API using [SWIG](http://www.swig.org/).

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -2,6 +2,7 @@
 title: Releases
 ---
 
+-   v1.9.9: Support INDI 1.9.9.  Fix implicit conversion between types
 -   v1.9.0: Change versioning convention. Major & minor reflects supported indilib 
 -   v0.2.8: Support INDI 1.9.0
 -   v0.2.7b: High-level INDI Property support (indi-core v1.9.0 dev).

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ except:
 
 ###
 
-VERSION = "v1.9.1"
+VERSION = "v1.9.9"
 root_dir = abspath(dirname(__file__))
 
 # Add search paths here for libindiclient.a


### PR DESCRIPTION
Bump version to match compatible indilib.  The latest pyindi-client changes are not backwards compatible with indi 1.9.8 and older.